### PR TITLE
🐛 Add check to see if gcloud is in path

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -57,6 +58,18 @@ var gcpInstallCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install a Flightcrew tower into Google Cloud Platform (GCP).",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !gcp.HasGcloudInPath() {
+			fmt.Printf(`The "gcloud" CLI tool is a pre-requisite to run this script.
+
+If you haven't yet, please install the tool: https://cloud.google.com/sdk/docs/install
+
+If you already have, please add it to your path:
+  export PATH=<where it is>:$PATH
+
+`)
+			return errors.New("gcloud is not in path")
+		}
+
 		if err := gcp.InitArtifactRegistry(); err != nil {
 			return fmt.Errorf("init artifact registry: %w", err)
 		}

--- a/internal/gcp/gcloud.go
+++ b/internal/gcp/gcloud.go
@@ -1,0 +1,14 @@
+package gcp
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+func HasGcloudInPath() bool {
+	cmd := exec.Command("bash", "-c", `which gcloud`)
+	var b bytes.Buffer
+	cmd.Stdout = &b
+	cmd.Stderr = &b
+	return cmd.Run() == nil
+}


### PR DESCRIPTION
Check that `gcloud` is in the PATH before running the script. Otherwise, exit before even running so that the user knows what the issue is.

#8