### PR TITLE
🌱 Move 1 populated project to placeholder, instead of value

### DIFF
--- a/internal/controller/gcpinstall/inputs.go
+++ b/internal/controller/gcpinstall/inputs.go
@@ -94,6 +94,11 @@ func NewInputsController(params Params) *InputsController {
 			input = wrapinput.NewFreeForm()
 			input.Freeform.CharLimit = 0
 			input.Freeform.Placeholder = "project-id-1234"
+			if projects, err := gcp.GetProjectsFromEnvironment(); err == nil {
+				if projectsStr := strings.Join(projects, ","); len(projectsStr) > 0 {
+					input.Freeform.Placeholder = projectsStr
+				}
+			}
 			input.Title = "Project ID"
 			input.HelpText = "Project ID is the unique string identifier for your Google Cloud Platform project."
 			input.Required = true

--- a/internal/controller/gcpinstall/inputs.go
+++ b/internal/controller/gcpinstall/inputs.go
@@ -94,10 +94,8 @@ func NewInputsController(params Params) *InputsController {
 			input = wrapinput.NewFreeForm()
 			input.Freeform.CharLimit = 0
 			input.Freeform.Placeholder = "project-id-1234"
-			if projects, err := gcp.GetProjectsFromEnvironment(); err == nil {
-				if projectsStr := strings.Join(projects, ","); len(projectsStr) > 0 {
-					input.Freeform.Placeholder = projectsStr
-				}
+			if project, err := gcp.GetProjectFromEnvironment(); err == nil && len(project) > 0 {
+				input.Freeform.Placeholder = project
 			}
 			input.Title = "Project ID"
 			input.HelpText = "Project ID is the unique string identifier for your Google Cloud Platform project."

--- a/internal/controller/gcpinstall/params.go
+++ b/internal/controller/gcpinstall/params.go
@@ -148,7 +148,7 @@ func recreateCommand(m map[string]string) string {
 	buf.WriteString(" gcp install")
 
 	for flagName, keyName := range flagToKey {
-		if val, ok := m[keyName]; ok {
+		if val, ok := m[keyName]; ok && len(val) > 0 {
 			switch keyName {
 			case keyPermissions:
 				if val == constants.Read {

--- a/internal/controller/gcpinstall/params.go
+++ b/internal/controller/gcpinstall/params.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"flightcrew.io/cli/internal/constants"
-	"flightcrew.io/cli/internal/gcp"
 	"github.com/spf13/cobra"
 )
 
@@ -95,12 +94,6 @@ func ParseFlags(cmd *cobra.Command) (Params, func(), error) {
 	}
 
 	maybeAddEnv(params.args, keyProject, *projectFlag)
-	if !contains(params.args, keyProject) {
-		if projects, err := gcp.GetProjectsFromEnvironment(); err == nil {
-			maybeAddEnv(params.args, keyProject, strings.Join(projects, ","))
-		}
-	}
-
 	maybeAddEnv(params.args, keyZone, *zoneFlag)
 	maybeAddEnv(params.args, keyTowerVersion, *versionFlag)
 	maybeAddEnv(params.args, keyAPIToken, *tokenFlag)

--- a/internal/gcp/project_test.go
+++ b/internal/gcp/project_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseProjectsCSV(mainT *testing.T) {
+func TestParseprojectCSV(mainT *testing.T) {
 	mainT.Run("parse valid csv should succeed", func(t *testing.T) {
 		buf := bytes.NewBufferString(`project_id
 project-1
@@ -15,14 +15,9 @@ some-project
 yeah
 123-project
 `)
-		projects, err := parseListProjectsCSV(buf)
+		project, err := parseListProjectsCSV(buf)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, []string{
-			"project-1",
-			"some-project",
-			"yeah",
-			"123-project",
-		}, projects)
+		assert.Equal(t, "project-1", project)
 	})
 
 	mainT.Run("parse empty csv should fail", func(t *testing.T) {
@@ -31,12 +26,11 @@ yeah
 		assert.Error(t, err)
 	})
 
-	mainT.Run("parse valid empty csv should succeed", func(t *testing.T) {
+	mainT.Run("parse valid empty csv should error", func(t *testing.T) {
 		buf := bytes.NewBufferString(`project_id
 `)
-		projects, err := parseListProjectsCSV(buf)
-		assert.NoError(t, err)
-		assert.Empty(t, projects)
+		_, err := parseListProjectsCSV(buf)
+		assert.Error(t, err)
 	})
 
 	mainT.Run("parse variable entries should succeed", func(t *testing.T) {
@@ -44,12 +38,9 @@ yeah
 ,project-1
 123,project-2
 	`)
-		projects, err := parseListProjectsCSV(buf)
+		project, err := parseListProjectsCSV(buf)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, []string{
-			"project-1",
-			"project-2",
-		}, projects)
+		assert.Equal(t, "project-1", project)
 	})
 
 	mainT.Run("parse invalid csv should error", func(t *testing.T) {


### PR DESCRIPTION
Moves the projects list (from `gcloud list projects`) to placeholder so that the user can see the projects for reference but not actually have to manually delete them when they want to modify the values

#8