### PR TITLE
🌱 Add resourcemanager.projects.get/list to permissions YAML

### DIFF
--- a/gcp/gae/iam_readonly.yaml
+++ b/gcp/gae/iam_readonly.yaml
@@ -5,6 +5,10 @@ stage: ALPHA
 # for how to read AppEngine versions:
 # https://cloud.google.com/iam/docs/understanding-roles#app-engine-roles
 includedPermissions:
+# Read projects
+- resourcemanager.projects.get
+- resourcemanager.projects.list
+
 # Read the Application config
 - appengine.applications.get
 - appengine.operations.get

--- a/gcp/gae/iam_readwrite.yaml
+++ b/gcp/gae/iam_readwrite.yaml
@@ -3,10 +3,6 @@ description: Grants Flightcrew's Control Tower VM write access to AppEngine conf
 stage: ALPHA
 # These permissions add to the Read-Only role to deploy new AppEngine versions.
 includedPermissions:
-# Read projects
-- resourcemanager.projects.get
-- resourcemanager.projects.list
-
 # Change the service's traffic splitting:
 - appengine.services.update
 

--- a/gcp/gae/iam_readwrite.yaml
+++ b/gcp/gae/iam_readwrite.yaml
@@ -3,6 +3,10 @@ description: Grants Flightcrew's Control Tower VM write access to AppEngine conf
 stage: ALPHA
 # These permissions add to the Read-Only role to deploy new AppEngine versions.
 includedPermissions:
+# Read projects
+- resourcemanager.projects.get
+- resourcemanager.projects.list
+
 # Change the service's traffic splitting:
 - appengine.services.update
 

--- a/gcp/gce/iam_readonly.yaml
+++ b/gcp/gce/iam_readonly.yaml
@@ -4,8 +4,11 @@ stage: ALPHA
 # These permissions are pared down from those specified in the GCP docs:
 # https://cloud.google.com/iam/docs/understanding-roles#compute-engine-roles
 includedPermissions:
+# Read projects
+- resourcemanager.projects.get
+- resourcemanager.projects.list
+
 # Read VM specs and configs
-- compute.projects.get
 - compute.zones.list
 - compute.instances.list
 

--- a/gcp/gce/iam_readonly.yaml
+++ b/gcp/gce/iam_readonly.yaml
@@ -5,6 +5,7 @@ stage: ALPHA
 # https://cloud.google.com/iam/docs/understanding-roles#compute-engine-roles
 includedPermissions:
 # Read VM specs and configs
+- compute.projects.get
 - compute.zones.list
 - compute.instances.list
 

--- a/internal/constants/platform.go
+++ b/internal/constants/platform.go
@@ -39,6 +39,10 @@ stage: ALPHA
 # for how to read AppEngine versions:
 # https://cloud.google.com/iam/docs/understanding-roles#app-engine-roles
 includedPermissions:
+# Read projects
+- resourcemanager.projects.get
+- resourcemanager.projects.list
+
 # Read the Application config
 - appengine.applications.get
 - appengine.operations.get
@@ -64,6 +68,10 @@ description: Grants Flightcrew's Control Tower VM write access to AppEngine conf
 stage: ALPHA
 # These permissions add to the Read-Only role to deploy new AppEngine versions.
 includedPermissions:
+# Read projects
+- resourcemanager.projects.get
+- resourcemanager.projects.list
+
 # Change the service's traffic splitting:
 - appengine.services.update
 
@@ -96,8 +104,11 @@ stage: ALPHA
 # These permissions are pared down from those specified in the GCP docs:
 # https://cloud.google.com/iam/docs/understanding-roles#compute-engine-roles
 includedPermissions:
+# Read projects
+- resourcemanager.projects.get
+- resourcemanager.projects.list
+
 # Read VM specs and configs
-- compute.projects.get
 - compute.zones.list
 - compute.instances.list
 

--- a/internal/constants/platform.go
+++ b/internal/constants/platform.go
@@ -97,6 +97,7 @@ stage: ALPHA
 # https://cloud.google.com/iam/docs/understanding-roles#compute-engine-roles
 includedPermissions:
 # Read VM specs and configs
+- compute.projects.get
 - compute.zones.list
 - compute.instances.list
 

--- a/internal/constants/platform.go
+++ b/internal/constants/platform.go
@@ -68,10 +68,6 @@ description: Grants Flightcrew's Control Tower VM write access to AppEngine conf
 stage: ALPHA
 # These permissions add to the Read-Only role to deploy new AppEngine versions.
 includedPermissions:
-# Read projects
-- resourcemanager.projects.get
-- resourcemanager.projects.list
-
 # Change the service's traffic splitting:
 - appengine.services.update
 

--- a/internal/controller/gcpinstall/inputs.go
+++ b/internal/controller/gcpinstall/inputs.go
@@ -228,7 +228,7 @@ func (ctl *InputsController) Validate(inputs []*wrapinput.Model) bool {
 			} else {
 				input.SetInfo("found organization ID '" + orgID + "'")
 				ctl.args[keyProjectOrOrgFlag] = fmtFlagForReplace("organization", orgID)
-				ctl.args[keyProjectOrOrgSlash] = fmt.Sprintf(`organization/%s`, orgID)
+				ctl.args[keyProjectOrOrgSlash] = fmt.Sprintf(`organizations/%s`, orgID)
 			}
 
 		case keyTowerVersion:
@@ -261,8 +261,12 @@ func (ctl *InputsController) Validate(inputs []*wrapinput.Model) bool {
 			platformInput := ctl.inputs[keyPlatform]
 			platform, ok := constants.DisplayToPlatform[platformInput.Value()]
 			if !ok {
-				// Validation of this field occurs in keyPlatform.
-				break
+				if _, ok := constants.PlatformPermissions[platformInput.Value()]; !ok {
+					setError(errors.New("need to set platform first"))
+					break
+				} else {
+					platform = platformInput.Value()
+				}
 			}
 
 			perms, ok := constants.PlatformPermissions[platform]
@@ -401,7 +405,7 @@ func fmtForReplace(value string) string {
 }
 
 func (ctl *InputsController) createFileWithContents(platform string, permissions string, contents string, extension string) (string, error) {
-	fn := filepath.Join(ctl.tempDir, filenameReplacer.Replace(fmt.Sprintf("%s_%s.%s", permissions, platform, extension)))
+	fn := filepath.Join(ctl.tempDir, fmt.Sprintf("%s.%s", filenameReplacer.Replace(fmt.Sprintf("%s_%s", permissions, platform)), extension))
 	if _, err := os.Stat(fn); err == nil {
 		return fn, nil
 	}

--- a/internal/controller/gcpinstall/params.go
+++ b/internal/controller/gcpinstall/params.go
@@ -32,9 +32,11 @@ const (
 	keyZone               = "${ZONE}"
 	keyVirtualMachine     = "${VIRTUAL_MACHINE}"
 	keyAPIToken           = "${API_TOKEN}"
-	keyIAMRole            = "${IAM_ROLE}"
 	keyIAMServiceAccount  = "${SERVICE_ACCOUNT}"
-	keyIAMFile            = "${IAM_FILE}"
+	keyIAMRoleRead        = "${READ_IAM_ROLE}"
+	keyIAMFileRead        = "${READ_IAM_FILE}"
+	keyIAMRoleWrite       = "${WRITE_IAM_ROLE}"
+	keyIAMFileWrite       = "${WRITE_IAM_FILE}"
 	keyPermissions        = "${PERMISSIONS}"
 	keyRPCHost            = "${RPC_HOST}"
 	keyAppURL             = "${APP_URL}"
@@ -118,10 +120,11 @@ func ParseFlags(cmd *cobra.Command) (Params, func(), error) {
 
 	maybeAddEnv(params.args, keyPlatform, displayName)
 
-	dir, err := os.MkdirTemp("", "flightcrew-gcp-install-*")
+	dir, err := os.MkdirTemp("/tmp", "flightcrew-gcp-install-*")
 	if err != nil {
 		return Params{}, nil, fmt.Errorf("create temp dir for installation: %v", err)
 	}
+	params.tempDir = dir
 
 	return params, func() {
 		err = os.RemoveAll(dir)

--- a/internal/controller/gcpinstall/run.go
+++ b/internal/controller/gcpinstall/run.go
@@ -16,8 +16,9 @@ type RunController struct {
 
 func NewRunController(args map[string]string) *RunController {
 	commands := make([]*command.Model, 0)
-	commands = append(commands, getServiceAccountCommands(args)...)
 	commands = append(commands, getIAMRoleCommands(args)...)
+	commands = append(commands, getServiceAccountCommands(args)...)
+	commands = append(commands, getBindIAMPolicyCommands(args)...)
 	commands = append(commands, getVMCommands(args)...)
 
 	replaceArgs := make([]string, 0, 2*len(args))
@@ -49,30 +50,6 @@ func (ctl RunController) RecreateCommand() string {
 	return recreateCommand(ctl.args)
 }
 
-func getServiceAccountCommands(args map[string]string) []*command.Model {
-	checkServiceAccount := command.NewReadModel(command.Opts{
-		Description: "Check if a Flightcrew service account already exists or needs to be created.",
-		Command:     `gcloud iam service-accounts describe --project="${GOOGLE_PROJECT_ID}" "${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" > /dev/null 2>&1`,
-		Message: map[command.State]string{
-			command.PassState: "The service account already exists.",
-			command.FailState: "No service account found. Next step is to create one.",
-		},
-	})
-	return []*command.Model{
-		checkServiceAccount,
-		command.NewWriteModel(command.Opts{
-			SkipIfSucceed: checkServiceAccount,
-			Description: `This command will create a service account, and follow-up commands will attach ${PERMISSIONS} permissions.
-
-https://cloud.google.com/iam/docs/creating-managing-service-accounts`,
-			Command: `gcloud iam service-accounts create "${SERVICE_ACCOUNT}" \
-	--project="${GOOGLE_PROJECT_ID}" \
-	--display-name="${SERVICE_ACCOUNT}" \
-	--description="Runs Flightcrew's Control Tower VM."`,
-		}),
-	}
-}
-
 func getIAMRoleCommands(args map[string]string) []*command.Model {
 	newCheckIAMRole := func(replacer *strings.Replacer) *command.Model {
 		cmd := command.NewReadModel(command.Opts{
@@ -97,13 +74,77 @@ func getIAMRoleCommands(args map[string]string) []*command.Model {
 		cmd.Replace(replacer)
 		return cmd
 	}
+
+	commands := make([]*command.Model, 0)
+
+	readReplacer := strings.NewReplacer(
+		"${ROLE}", args[keyIAMRoleRead],
+		"${FILE}", args[keyIAMFileRead],
+		"${PERMISSIONS}", constants.Read)
+	checkReadIAMRole := newCheckIAMRole(readReplacer)
+	commands = append(commands,
+		checkReadIAMRole,
+		newCreateIAMRole(readReplacer, checkReadIAMRole))
+
+	if args[keyPermissions] == constants.Write {
+		writeReplacer := strings.NewReplacer(
+			"${ROLE}", args[keyIAMRoleWrite],
+			"${FILE}", args[keyIAMFileWrite],
+			"${PERMISSIONS}", constants.Write)
+		checkWriteIAMRole := newCheckIAMRole(writeReplacer)
+		commands = append(commands,
+			checkWriteIAMRole,
+			newCreateIAMRole(writeReplacer, checkWriteIAMRole))
+	}
+
+	return commands
+}
+
+func getServiceAccountCommands(args map[string]string) []*command.Model {
+	checkServiceAccount := command.NewReadModel(command.Opts{
+		Description: "Check if a Flightcrew service account already exists or needs to be created.",
+		Command:     `gcloud iam service-accounts describe --project="${GOOGLE_PROJECT_ID}" "${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" > /dev/null 2>&1`,
+		Message: map[command.State]string{
+			command.PassState: "The service account already exists.",
+			command.FailState: "No service account found. Next step is to create one.",
+		},
+	})
+	return []*command.Model{
+		checkServiceAccount,
+		command.NewWriteModel(command.Opts{
+			SkipIfSucceed: checkServiceAccount,
+			Description: `This command will create a service account, and follow-up commands will attach ${PERMISSIONS} permissions.
+
+https://cloud.google.com/iam/docs/creating-managing-service-accounts`,
+			Command: `gcloud iam service-accounts create "${SERVICE_ACCOUNT}" \
+	--project="${GOOGLE_PROJECT_ID}" \
+	--display-name="${SERVICE_ACCOUNT}" \
+	--description="Runs Flightcrew's Control Tower VM."`,
+		}),
+	}
+}
+
+func getBindIAMPolicyCommands(args map[string]string) []*command.Model {
+	newCheckPolicy := func(replacer *strings.Replacer) *command.Model {
+		cmd := command.NewReadModel(command.Opts{
+			Description: "Check if IAM policy binding already exists or needs to be created.",
+			Command:     `gcloud projects get-iam-policy ${GOOGLE_PROJECT_ID} --filter="bindings.role=${PROJECT_OR_ORG_SLASH}/roles/${ROLE}"  --flatten=bindings --format="table(bindings.members,bindings.role)" | grep --quiet "'serviceAccount:${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com'"`,
+			Message: map[command.State]string{
+				command.PassState: "Binding already exists.",
+				command.FailState: "Binding doesn't exist. Next step is to add the binding.",
+			},
+		})
+		cmd.Replace(replacer)
+		return cmd
+	}
+
 	newAttachPolicy := func(replacer *strings.Replacer, skipIfSucceed *command.Model) *command.Model {
 		cmd := command.NewWriteModel(command.Opts{
 			SkipIfSucceed: skipIfSucceed,
-			Description: `This command attaches the ${PERMISSIONS} IAM role to Flightcrew's service account, which will give the attached permissions to a new VM.
+			Description: `This command binds the ${PERMISSIONS} IAM role to the created service account, which grants the associated permissions to Flightcrew's service account for running the to-be-created VM.
 
 https://cloud.google.com/iam/docs/granting-changing-revoking-access`,
-			Command: `gcloud projects get-iam-policy-binding "${GOOGLE_PROJECT_ID}" \
+			Command: `gcloud projects add-iam-policy-binding "${GOOGLE_PROJECT_ID}" \
 	--member=serviceAccount:"${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" \
 	--role="${PROJECT_OR_ORG_SLASH}/roles/${ROLE}" \
 	--condition=None`,
@@ -115,23 +156,19 @@ https://cloud.google.com/iam/docs/granting-changing-revoking-access`,
 	commands := make([]*command.Model, 0)
 
 	readReplacer := strings.NewReplacer(
-		"${ROLE}", args[keyIAMRoleRead],
-		"${FILE}", args[keyIAMFileRead],
-		"${PERMISSIONS}", constants.Read)
-	checkReadIAMRole := newCheckIAMRole(readReplacer)
-	commands = append(commands, checkReadIAMRole)
-	commands = append(commands, newCreateIAMRole(readReplacer, checkReadIAMRole))
-	commands = append(commands, newAttachPolicy(readReplacer, checkReadIAMRole))
+		"${ROLE}", keyIAMRoleRead,
+		"${PERMISSIONS}", constants.Read,
+	)
+	readCheck := newCheckPolicy(readReplacer)
+	commands = append(commands, readCheck, newAttachPolicy(readReplacer, readCheck))
 
 	if args[keyPermissions] == constants.Write {
 		writeReplacer := strings.NewReplacer(
-			"${ROLE}", args[keyIAMRoleWrite],
-			"${FILE}", args[keyIAMFileWrite],
-			"${PERMISSIONS}", constants.Write)
-		checkWriteIAMRole := newCheckIAMRole(writeReplacer)
-		commands = append(commands, checkWriteIAMRole)
-		commands = append(commands, newCreateIAMRole(writeReplacer, checkWriteIAMRole))
-		commands = append(commands, newAttachPolicy(writeReplacer, checkWriteIAMRole))
+			"${ROLE}", keyIAMRoleWrite,
+			"${PERMISSIONS}", constants.Write,
+		)
+		writeCheck := newCheckPolicy(writeReplacer)
+		commands = append(commands, writeCheck, newAttachPolicy(writeReplacer, writeCheck))
 	}
 
 	return commands
@@ -174,7 +211,7 @@ func getVMCommands(args map[string]string) []*command.Model {
 		}),
 		command.NewWriteModel(command.Opts{
 			SkipIfSucceed: checkVMExists,
-			Command: `gcloud compute instances get-metadata ${VIRTUAL_MACHINE} \
+			Command: `gcloud compute instances add-metadata ${VIRTUAL_MACHINE} \
 	--project=${GOOGLE_PROJECT_ID} \
 	--zone=${ZONE}  \
 	--metadata=google-logging-enabled=false`,

--- a/internal/controller/gcpinstall/run.go
+++ b/internal/controller/gcpinstall/run.go
@@ -3,6 +3,7 @@ package gcpinstall
 import (
 	"strings"
 
+	"flightcrew.io/cli/internal/constants"
 	"flightcrew.io/cli/internal/controller"
 	"flightcrew.io/cli/internal/view/command"
 )
@@ -14,95 +15,10 @@ type RunController struct {
 }
 
 func NewRunController(args map[string]string) *RunController {
-	checkServiceAccount := command.NewReadModel(command.Opts{
-		Description: "Check if a Flightcrew service account already exists or needs to be created.",
-		Command:     `gcloud iam service-accounts describe --project="${GOOGLE_PROJECT_ID}" "${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" > /dev/null 2>&1`,
-		Message: map[command.State]string{
-			command.PassState: "The service account already exists.",
-			command.FailState: "No service account found. Next step is to create one.",
-		},
-	})
-	checkIAMRole := command.NewReadModel(command.Opts{
-		Description: "Check if a Flightcrew IAM Role already exists or needs to be created.",
-		Command:     `gcloud iam roles describe --project="${GOOGLE_PROJECT_ID}" "${IAM_ROLE}" >/dev/null 2>&1`,
-		Message: map[command.State]string{
-			command.PassState: "This Flightcrew IAM role already exists.",
-			command.FailState: "No IAM role found. Next step is to create one.",
-		},
-	})
-	checkVMExists := command.NewReadModel(command.Opts{
-		Description: "Check if a Flightcrew VM already exists or needs to be created.",
-		Command: `gcloud compute instances list --format="csv(NAME,EXTERNAL_IP,STATUS)" \${PROJECT_OR_ORG_FLAG}
-	--zones=${ZONE} | awk -F "," "/${VIRTUAL_MACHINE}/ {print f(2), f(3)} function f(n){return (\$n==\"\" ? \"null\" : \$n)}" | [ $(wc -c) -gt "0" ]`,
-		Message: map[command.State]string{
-			command.PassState: "This Flightcrew VM already exists. Nothing to install.",
-			command.FailState: "No existing VM found. Next step is to create it.",
-		},
-	})
-
-	commands := []*command.Model{
-		checkServiceAccount,
-		command.NewWriteModel(command.Opts{
-			SkipIfSucceed: checkServiceAccount,
-			Description: `This command will create a service account, and follow-up commands will attach ${PERMISSIONS} permissions.
-
-https://cloud.google.com/iam/docs/creating-managing-service-accounts`,
-			Command: `gcloud iam service-accounts create "${SERVICE_ACCOUNT}" \
-	--project="${GOOGLE_PROJECT_ID}" \
-	--display-name="${SERVICE_ACCOUNT}" \
-	--description="Runs Flightcrew's Control Tower VM."`,
-		}),
-		checkIAMRole,
-		command.NewWriteModel(command.Opts{
-			SkipIfSucceed: checkIAMRole,
-			Description:   "This command creates an IAM role from `${IAM_FILE}` for the Flightcrew VM to access configs and monitoring data.\n\nhttps://cloud.google.com/iam/docs/understanding-custom-roles",
-			Command: `gcloud iam roles create ${IAM_ROLE} \${PROJECT_OR_ORG_FLAG}
-	--file=${IAM_FILE}`,
-		}),
-		command.NewWriteModel(command.Opts{
-			SkipIfSucceed: checkIAMRole,
-			Description: `This command attaches the IAM role to Flightcrew's service account, which will give the IAM permissions to a new VM.
-
-https://cloud.google.com/iam/docs/granting-changing-revoking-access`,
-			Command: `gcloud projects add-iam-policy-binding "${GOOGLE_PROJECT_ID}" \
-	--member=serviceAccount:"${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" \
-	--role="${PROJECT_OR_ORG_SLASH}/roles/${IAM_ROLE}" \
-	--condition=None`,
-		}),
-		checkVMExists,
-		command.NewWriteModel(command.Opts{
-			SkipIfSucceed: checkVMExists,
-			Description:   "Create a VM instance attached to Flightcrew's service account, and run the Control Tower image.",
-			Command: `gcloud compute instances create-with-container ${VIRTUAL_MACHINE} \
-	--project=${GOOGLE_PROJECT_ID} \
-	--container-command="/ko-app/tower" \
-	--container-image="${IMAGE_PATH}:${TOWER_VERSION}" \
-	--container-arg="--debug=true" \
-	--container-env="FC_API_KEY=${API_TOKEN}" \
-	--container-env="CLOUD_PLATFORM=${PLATFORM}" \${TRAFFIC_ROUTER}${GAE_MAX_VERSION_COUNT}${GAE_MAX_VERSION_AGE}
-	--container-env="FC_PACKAGE_VERSION=${TOWER_VERSION}" \
-	--container-env="METRIC_PROVIDERS=stackdriver" \
-	--container-env="FC_RPC_CONNECT_HOST=${RPC_HOST}" \
-	--container-env="FC_RPC_CONNECT_PORT=443" \
-	--container-env="FC_TOWER_PORT=8080" \
-	--labels="component=flightcrew" \
-	--machine-type="e2-micro" \
-	--scopes="cloud-platform" \
-	--service-account="${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" \
-	--tags="http-server" \
-	--zone="${ZONE}"`,
-		}),
-		command.NewWriteModel(command.Opts{
-			SkipIfSucceed: checkVMExists,
-			Command: `gcloud compute instances add-metadata ${VIRTUAL_MACHINE} \
-	--project=${GOOGLE_PROJECT_ID} \
-	--zone=${ZONE}  \
-	--metadata=google-logging-enabled=false`,
-			Description: `Disable the VM's builtin logger because it has a memory leak and will cause the VM to crash after 1-2 weeks.
-
-https://serverfault.com/questions/980569/disable-fluentd-on-on-container-optimized-os-gce`,
-		}),
-	}
+	commands := make([]*command.Model, 0)
+	commands = append(commands, getServiceAccountCommands(args)...)
+	commands = append(commands, getIAMRoleCommands(args)...)
+	commands = append(commands, getVMCommands(args)...)
 
 	replaceArgs := make([]string, 0, 2*len(args))
 	for key, arg := range args {
@@ -131,4 +47,131 @@ func (ctl *RunController) GetEndController() controller.End {
 
 func (ctl RunController) RecreateCommand() string {
 	return recreateCommand(ctl.args)
+}
+
+func getServiceAccountCommands(args map[string]string) []*command.Model {
+	checkServiceAccount := command.NewReadModel(command.Opts{
+		Description: "Check if a Flightcrew service account already exists or needs to be created.",
+		Command:     `gcloud iam service-accounts describe --project="${GOOGLE_PROJECT_ID}" "${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" > /dev/null 2>&1`,
+		Message: map[command.State]string{
+			command.PassState: "The service account already exists.",
+			command.FailState: "No service account found. Next step is to create one.",
+		},
+	})
+	return []*command.Model{
+		checkServiceAccount,
+		command.NewWriteModel(command.Opts{
+			SkipIfSucceed: checkServiceAccount,
+			Description: `This command will create a service account, and follow-up commands will attach ${PERMISSIONS} permissions.
+
+https://cloud.google.com/iam/docs/creating-managing-service-accounts`,
+			Command: `gcloud iam service-accounts create "${SERVICE_ACCOUNT}" \
+	--project="${GOOGLE_PROJECT_ID}" \
+	--display-name="${SERVICE_ACCOUNT}" \
+	--description="Runs Flightcrew's Control Tower VM."`,
+		}),
+	}
+}
+
+func getIAMRoleCommands(args map[string]string) []*command.Model {
+	checkIAMRole := command.NewReadModel(command.Opts{
+		Description: "Check if a Flightcrew IAM Role already exists or needs to be created.",
+		Command:     `gcloud iam roles describe --project="${GOOGLE_PROJECT_ID}" "${IAM_ROLE}" >/dev/null 2>&1`,
+		Message: map[command.State]string{
+			command.PassState: "This Flightcrew IAM role already exists.",
+			command.FailState: "No IAM role found. Next step is to create one.",
+		},
+	})
+	// TODO: Create the read-only
+	commands := []*command.Model{
+		checkIAMRole,
+		command.NewWriteModel(command.Opts{
+			SkipIfSucceed: checkIAMRole,
+			Description:   "This command creates an IAM role from `${IAM_FILE}` for the Flightcrew VM to access configs and monitoring data.\n\nhttps://cloud.google.com/iam/docs/understanding-custom-roles",
+			Command: `gcloud iam roles create ${IAM_ROLE} \${PROJECT_OR_ORG_FLAG}
+	--file=${IAM_FILE}`,
+		}),
+		command.NewWriteModel(command.Opts{
+			SkipIfSucceed: checkIAMRole,
+			Description: `This command attaches the IAM role to Flightcrew's service account, which will give the IAM permissions to a new VM.
+
+https://cloud.google.com/iam/docs/granting-changing-revoking-access`,
+			Command: `gcloud projects get-iam-policy-binding "${GOOGLE_PROJECT_ID}" \
+	--member=serviceAccount:"${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" \
+	--role="${PROJECT_OR_ORG_SLASH}/roles/${IAM_ROLE}" \
+	--condition=None`,
+		}),
+	}
+
+	// TODOThen create the write
+	if args[keyPermissions] == constants.Write {
+		commands = append(commands,
+			command.NewWriteModel(command.Opts{
+				SkipIfSucceed: checkIAMRole,
+				Description:   "This command creates an IAM role from `${IAM_FILE}` for the Flightcrew VM to access configs and monitoring data.\n\nhttps://cloud.google.com/iam/docs/understanding-custom-roles",
+				Command: `gcloud iam roles create ${IAM_ROLE} \${PROJECT_OR_ORG_FLAG}
+		--file=${IAM_FILE}`,
+			}),
+			command.NewWriteModel(command.Opts{
+				SkipIfSucceed: checkIAMRole,
+				Description: `This command attaches the IAM role to Flightcrew's service account, which will give the IAM permissions to a new VM.
+
+	https://cloud.google.com/iam/docs/granting-changing-revoking-access`,
+				Command: `gcloud projects get-iam-policy-binding "${GOOGLE_PROJECT_ID}" \
+		--member=serviceAccount:"${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" \
+		--role="${PROJECT_OR_ORG_SLASH}/roles/${IAM_ROLE}" \
+		--condition=None`,
+			}),
+		)
+	}
+
+	return commands
+}
+
+func getVMCommands(args map[string]string) []*command.Model {
+	checkVMExists := command.NewReadModel(command.Opts{
+		Description: "Check if a Flightcrew VM already exists or needs to be created.",
+		Command: `gcloud compute instances list --format="csv(NAME,EXTERNAL_IP,STATUS)" \${PROJECT_OR_ORG_FLAG}
+	--zones=${ZONE} | awk -F "," "/${VIRTUAL_MACHINE}/ {print f(2), f(3)} function f(n){return (\$n==\"\" ? \"null\" : \$n)}" | [ $(wc -c) -gt "0" ]`,
+		Message: map[command.State]string{
+			command.PassState: "This Flightcrew VM already exists. Nothing to install.",
+			command.FailState: "No existing VM found. Next step is to create it.",
+		},
+	})
+
+	return []*command.Model{
+		checkVMExists,
+		command.NewWriteModel(command.Opts{
+			SkipIfSucceed: checkVMExists,
+			Description:   "Create a VM instance attached to Flightcrew's service account, and run the Control Tower image.",
+			Command: `gcloud compute instances create-with-container ${VIRTUAL_MACHINE} \
+	--project=${GOOGLE_PROJECT_ID} \
+	--container-command="/ko-app/tower" \
+	--container-image="${IMAGE_PATH}:${TOWER_VERSION}" \
+	--container-arg="--debug=true" \
+	--container-env="FC_API_KEY=${API_TOKEN}" \
+	--container-env="CLOUD_PLATFORM=${PLATFORM}" \${TRAFFIC_ROUTER}${GAE_MAX_VERSION_COUNT}${GAE_MAX_VERSION_AGE}
+	--container-env="FC_PACKAGE_VERSION=${TOWER_VERSION}" \
+	--container-env="METRIC_PROVIDERS=stackdriver" \
+	--container-env="FC_RPC_CONNECT_HOST=${RPC_HOST}" \
+	--container-env="FC_RPC_CONNECT_PORT=443" \
+	--container-env="FC_TOWER_PORT=8080" \
+	--labels="component=flightcrew" \
+	--machine-type="e2-micro" \
+	--scopes="cloud-platform" \
+	--service-account="${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" \
+	--tags="http-server" \
+	--zone="${ZONE}"`,
+		}),
+		command.NewWriteModel(command.Opts{
+			SkipIfSucceed: checkVMExists,
+			Command: `gcloud compute instances get-metadata ${VIRTUAL_MACHINE} \
+	--project=${GOOGLE_PROJECT_ID} \
+	--zone=${ZONE}  \
+	--metadata=google-logging-enabled=false`,
+			Description: `Disable the VM's builtin logger because it has a memory leak and will cause the VM to crash after 1-2 weeks.
+
+https://serverfault.com/questions/980569/disable-fluentd-on-on-container-optimized-os-gce`,
+		}),
+	}
 }

--- a/internal/view/wrapinput/wrapinput.go
+++ b/internal/view/wrapinput/wrapinput.go
@@ -62,7 +62,15 @@ func (m Model) View(params ViewParams) string {
 	b.WriteString(": ")
 
 	if params.ShowValue {
-		b.WriteString(m.Value())
+		if m.Radio != nil {
+			b.WriteString(m.Radio.Value())
+		} else if m.Freeform != nil {
+			if val := m.Freeform.Value(); len(val) > 0 {
+				b.WriteString(m.Freeform.Value())
+			} else {
+				b.WriteString(m.Default)
+			}
+		}
 		if len(m.validation.ErrorMessage) > 0 {
 			b.WriteString(" ❗️ ")
 			b.WriteString(style.Error(m.validation.ErrorMessage))


### PR DESCRIPTION
Compute Engine only reads the instances and zones right now. For Compute Engine across multiple projects, we want to be able to read other projects as well, not just the one where the Tower is located in.

#8