### PR TITLE
🌱 Change from using project id to using organization id for IAM role

### DIFF
--- a/internal/controller/gcpinstall/inputs.go
+++ b/internal/controller/gcpinstall/inputs.go
@@ -212,6 +212,16 @@ func (ctl *InputsController) Validate(inputs []*wrapinput.Model) bool {
 		}
 
 		switch k {
+		case keyProject:
+			projectID := input.Value()
+			orgID, err := gcp.GetOrganizationID(projectID)
+			if setError(err) {
+				break
+			}
+
+			input.SetInfo("found organization ID '" + orgID + "'")
+			ctl.args[keyOrgID] = orgID
+
 		case keyTowerVersion:
 			version, err := gcp.GetTowerImageVersion(input.Value())
 			if setError(err) {

--- a/internal/controller/gcpinstall/params.go
+++ b/internal/controller/gcpinstall/params.go
@@ -29,7 +29,6 @@ const (
 
 const (
 	keyProject            = "${GOOGLE_PROJECT_ID}"
-	keyOrgID              = "${GOOGLE_ORG_ID}"
 	keyTowerVersion       = "${TOWER_VERSION}"
 	keyZone               = "${ZONE}"
 	keyVirtualMachine     = "${VIRTUAL_MACHINE}"
@@ -46,6 +45,8 @@ const (
 	keyTempDir            = "${TEMP_DIR}"
 	keyGAEMaxVersionCount = "${GAE_MAX_VERSION_COUNT}"
 	keyGAEMaxVersionAge   = "${GAE_MAX_VERSION_AGE}"
+	keyProjectOrOrgFlag   = "${PROJECT_OR_ORG_FLAG}"
+	keyProjectOrOrgSlash  = "${PROJECT_OR_ORG_SLASH}"
 )
 
 var (

--- a/internal/controller/gcpinstall/params.go
+++ b/internal/controller/gcpinstall/params.go
@@ -29,6 +29,7 @@ const (
 
 const (
 	keyProject            = "${GOOGLE_PROJECT_ID}"
+	keyOrgID              = "${GOOGLE_ORG_ID}"
 	keyTowerVersion       = "${TOWER_VERSION}"
 	keyZone               = "${ZONE}"
 	keyVirtualMachine     = "${VIRTUAL_MACHINE}"

--- a/internal/controller/gcpinstall/run.go
+++ b/internal/controller/gcpinstall/run.go
@@ -54,9 +54,9 @@ https://cloud.google.com/iam/docs/creating-managing-service-accounts`,
 		checkIAMRole,
 		command.NewWriteModel(command.Opts{
 			SkipIfSucceed: checkIAMRole,
-			Description:   "This command creates an IAM role from `${IAM_FILE}` for the Flightcrew VM to access configs and monitoring data.\n\nhttps://cloud.google.com/iam/docs/understanding-custom-roles",
+			Description:   "This command creates an IAM role from `${IAM_FILE}` under your GCP organization for the Flightcrew VM to access configs and monitoring data.\n\nhttps://cloud.google.com/iam/docs/understanding-custom-roles",
 			Command: `gcloud iam roles create ${IAM_ROLE} \
-	--project=${GOOGLE_PROJECT_ID} \
+	--organization=${GOOGLE_ORG_ID} \
 	--file=${IAM_FILE}`,
 		}),
 		command.NewWriteModel(command.Opts{
@@ -66,7 +66,7 @@ https://cloud.google.com/iam/docs/creating-managing-service-accounts`,
 https://cloud.google.com/iam/docs/granting-changing-revoking-access`,
 			Command: `gcloud projects add-iam-policy-binding "${GOOGLE_PROJECT_ID}" \
 	--member=serviceAccount:"${SERVICE_ACCOUNT}@${GOOGLE_PROJECT_ID}.iam.gserviceaccount.com" \
-	--role="projects/${GOOGLE_PROJECT_ID}/roles/${IAM_ROLE}" \
+	--role="organizations/${GOOGLE_ORG_ID}/roles/${IAM_ROLE}" \
 	--condition=None`,
 		}),
 		checkVMExists,

--- a/internal/gcp/organization.go
+++ b/internal/gcp/organization.go
@@ -1,0 +1,36 @@
+package gcp
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func GetOrganizationID(projectID string) (string, error) {
+	var stdout, stderr bytes.Buffer
+	err := bashGetAncestors(projectID, &stdout, &stderr)
+	if err != nil {
+		return "", err
+	}
+
+	orgID := strings.Trim(stdout.String(), " \n\t")
+	if len(orgID) == 0 {
+		return "", errors.New("not found: Google organization ID")
+	}
+
+	return orgID, nil
+}
+
+func bashGetAncestors(projectID string, stdout, stderr *bytes.Buffer) error {
+	cmdStr := strings.Replace("gcloud projects get-ancestors ${PROJECT_ID} | awk '/organization/ {print $1}'", "${PROJECT_ID}", projectID, 1)
+	c := exec.Command("bash", "-c", cmdStr)
+	c.Stdout = stdout
+	c.Stderr = stderr
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("gcloud projects get-ancestors: %w", err)
+	}
+
+	return nil
+}

--- a/internal/view/command/exec_test.go
+++ b/internal/view/command/exec_test.go
@@ -1,0 +1,50 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeCommandForExec(t *testing.T) {
+	type testCase struct {
+		input string
+		want  string
+	}
+	for _, tc := range []testCase{
+		{
+			input: `gcloud compute instances create-with-container fc-ct-gae-std-dev \
+	--project=project-id-1234 \
+	--container-command="/ko-app/tower" \
+	--container-image="us-west1-docker.pkg.dev/flightcrew-artifacts/client/tower:0.2.15" \
+	--container-arg="--debug=true" \
+	--container-env="FC_API_KEY=example-token-1234" \
+	--container-env="CLOUD_PLATFORM=provider:gcp/platform:compute/type:instances" \
+	--container-env="FC_PACKAGE_VERSION=0.2.15" \
+	--container-env="METRIC_PROVIDERS=stackdriver" \
+	--container-env="FC_RPC_CONNECT_HOST=host.example.com" \
+	--container-env="FC_RPC_CONNECT_PORT=443" \
+	--container-env="FC_TOWER_PORT=8080" \
+	--labels="component=flightcrew" \
+	--machine-type="e2-micro" \
+	--scopes="cloud-platform" \
+	--service-account="flightcrew-runner@project-id-1234.iam.gserviceaccount.com" \
+	--tags="http-server" \
+	--zone="us-west2-a"`,
+			want: `gcloud compute instances create-with-container fc-ct-gae-std-dev --project=project-id-1234 --container-command="/ko-app/tower" --container-image="us-west1-docker.pkg.dev/flightcrew-artifacts/client/tower:0.2.15" --container-arg="--debug=true" --container-env="FC_API_KEY=example-token-1234" --container-env="CLOUD_PLATFORM=provider:gcp/platform:compute/type:instances" --container-env="FC_PACKAGE_VERSION=0.2.15" --container-env="METRIC_PROVIDERS=stackdriver" --container-env="FC_RPC_CONNECT_HOST=host.example.com" --container-env="FC_RPC_CONNECT_PORT=443" --container-env="FC_TOWER_PORT=8080" --labels="component=flightcrew" --machine-type="e2-micro" --scopes="cloud-platform" --service-account="flightcrew-runner@project-id-1234.iam.gserviceaccount.com" --tags="http-server" --zone="us-west2-a"`,
+		},
+		{
+			input: `gcloud compute instances list --format="csv(NAME,EXTERNAL_IP,STATUS)" \
+	--organization="1234567890" \
+	--zones=us-west2-a | awk -F "," "/vm-name/ {print f(2), f(3)} function f(n){return(\$n==\"\" ? \"null\" : \$n)}" | [ $(wc -c) -gt "0" ]`,
+			want: `gcloud compute instances list --format="csv(NAME,EXTERNAL_IP,STATUS)" --organization="1234567890" --zones=us-west2-a | awk -F "," "/vm-name/ {print f(2), f(3)} function f(n){return(\$n==\"\" ? \"null\" : \$n)}" | [ $(wc -c) -gt "0" ]`,
+		},
+		{
+			input: `ls`,
+			want:  `ls`,
+		},
+	} {
+		assert.Equal(t, tc.want, sanitizeForExec(tc.input))
+	}
+
+}

--- a/internal/view/command/print.go
+++ b/internal/view/command/print.go
@@ -8,7 +8,7 @@ func (m Model) String() string {
 	var out strings.Builder
 	out.WriteString(m.opts.Description)
 	out.WriteString("\n\n```sh\n")
-	out.WriteString(m.opts.Command)
+	out.WriteString(sanitizeForExec(m.opts.Command))
 	out.WriteString("\n```\n\n")
 
 	switch m.state {


### PR DESCRIPTION
Using only project ID makes it difficult to monitor all VMs in the organization. Changing to organization allows our VM to read across multiple projects.

Falls back to the project if we can't get the organization (or the user doesn't have the permissions to look at the organiation)

I rewrote `sanitizeForExec` because I suspect the previous implementation was buggy -- I also added tests to make sure it returns what we expect.

#8